### PR TITLE
feat: load image before each inference

### DIFF
--- a/dlr/aws.greengrass.DLRImageClassification/image_classification/inference.py
+++ b/dlr/aws.greengrass.DLRImageClassification/image_classification/inference.py
@@ -57,9 +57,6 @@ def set_configuration(config):
     if new_config["use_camera"].lower() == "true":
         prediction_utils.enable_camera()
 
-    new_config["image"] = prediction_utils.load_image(
-        path.join(new_config["image_dir"], new_config["image_name"])
-    )
     # Run inference with the updated config indicating the config change.
     run_inference(new_config, True)
 
@@ -80,7 +77,10 @@ def run_inference(new_config, config_changed):
     if new_config["use_camera"].lower() == "true":
         prediction_utils.predict_from_cam()
     else:
-        prediction_utils.predict_from_image(new_config["image"])
+        image = prediction_utils.load_image(
+            path.join(new_config["image_dir"], new_config["image_name"])
+        )
+        prediction_utils.predict_from_image(image)
     config_utils.SCHEDULED_THREAD = Timer(
         int(new_config["prediction_interval_secs"]), run_inference, [new_config, config_changed]
     )

--- a/dlr/aws.greengrass.DLRObjectDetection/object_detection/inference.py
+++ b/dlr/aws.greengrass.DLRObjectDetection/object_detection/inference.py
@@ -57,10 +57,6 @@ def set_configuration(config):
     if new_config["use_camera"].lower() == "true":
         prediction_utils.enable_camera()
 
-    new_config["image"] = prediction_utils.load_image(
-        path.join(new_config["image_dir"], new_config["image_name"])
-    )
-
     # Create the directory for output images with overlaid bounding boxes, if it does not exist already
     makedirs(config_utils.BOUNDED_OUTPUT_DIR, exist_ok=True)
 
@@ -84,7 +80,10 @@ def run_inference(new_config, config_changed):
     if new_config["use_camera"].lower() == "true":
         prediction_utils.predict_from_cam()
     else:
-        prediction_utils.predict_from_image(new_config["image"])
+        image = prediction_utils.load_image(
+            path.join(new_config["image_dir"], new_config["image_name"])
+        )
+        prediction_utils.predict_from_image(image)
     config_utils.SCHEDULED_THREAD = Timer(
         int(new_config["prediction_interval_secs"]),
         run_inference,

--- a/tflite/aws.greengrass.TensorFlowLiteImageClassification/image_classification/inference.py
+++ b/tflite/aws.greengrass.TensorFlowLiteImageClassification/image_classification/inference.py
@@ -56,10 +56,6 @@ def set_configuration(config):
     if new_config["use_camera"].lower() == "true":
         prediction_utils.enable_camera()
 
-    new_config["image"] = prediction_utils.load_image(
-        path.join(new_config["image_dir"], new_config["image_name"])
-    )
-
     # Run inference with the updated config indicating the config change.
     run_inference(new_config, True)
 
@@ -80,7 +76,10 @@ def run_inference(new_config, config_changed):
     if new_config["use_camera"].lower() == "true":
         prediction_utils.predict_from_cam()
     else:
-        prediction_utils.predict_from_image(new_config["image"])
+        image = prediction_utils.load_image(
+            path.join(new_config["image_dir"], new_config["image_name"])
+        )
+        prediction_utils.predict_from_image(image)
     config_utils.SCHEDULED_THREAD = threading.Timer(
         int(new_config["prediction_interval_secs"]), run_inference, [new_config, config_changed]
     )

--- a/tflite/aws.greengrass.TensorFlowLiteObjectDetection/object_detection/inference.py
+++ b/tflite/aws.greengrass.TensorFlowLiteObjectDetection/object_detection/inference.py
@@ -56,10 +56,6 @@ def set_configuration(config):
     if new_config["use_camera"].lower() == "true":
         prediction_utils.enable_camera()
 
-    new_config["image"] = prediction_utils.load_image(
-        path.join(new_config["image_dir"], new_config["image_name"])
-    )
-
     # Create the directory for output images with overlaid bounding boxes, if it does not exist already
     makedirs(config_utils.BOUNDED_OUTPUT_DIR, exist_ok=True)
 
@@ -83,7 +79,10 @@ def run_inference(new_config, config_changed):
     if new_config["use_camera"].lower() == "true":
         prediction_utils.predict_from_cam()
     else:
-        prediction_utils.predict_from_image(new_config["image"])
+        image = prediction_utils.load_image(
+            path.join(new_config["image_dir"], new_config["image_name"])
+        )
+        prediction_utils.predict_from_image(image)
     config_utils.SCHEDULED_THREAD = threading.Timer(
         int(new_config["prediction_interval_secs"]), run_inference, [new_config, config_changed]
     )


### PR DESCRIPTION
fixes https://github.com/awslabs/aws-greengrass-labs-ml-components/issues/7

*Description of changes:*
This PR moves the image loading to the run_inference function. 
This way, if the file changes, inference is being done on the latest content.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
